### PR TITLE
Implement threadpool for WasmMP

### DIFF
--- a/include/wavm/PlatformThreadPool.h
+++ b/include/wavm/PlatformThreadPool.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+#include <WAVM/Runtime/Runtime.h>
+#include <WAVM/Inline/BasicTypes.h>
+#include <WAVM/Platform/Thread.h>
+
+#include <util/locks.h>
+#include <util/locks.h>
+#include <wavm/PlatformThreadPool.h>
+
+namespace wasm {
+
+    using namespace WAVM;
+    class WAVMWasmModule;
+
+    namespace openmp {
+        struct LocalThreadArgs;
+    }
+
+    class PlatformThreadPool {
+    public:
+        PlatformThreadPool(size_t numThreads, WAVMWasmModule *module);
+
+        friend I64 workerEntryFunc(void* _args);
+
+        std::future<I64> runThread(openmp::LocalThreadArgs &&threadArgs);
+
+        ~PlatformThreadPool();
+
+    private:
+        std::queue<std::pair<std::promise<I64>, openmp::LocalThreadArgs>> tasks;
+        std::vector<WAVM::Platform::Thread *> workers;
+
+        std::mutex mutexQueue;
+        std::condition_variable condition;
+        bool stop = false;
+    };
+
+    struct WorkerArgs {
+        U32 stackTop;
+        PlatformThreadPool *pool;
+    };
+
+}
+

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <wasm/WasmModule.h>
-
 #include <WAVM/Runtime/Intrinsics.h>
 #include <WAVM/Runtime/Linker.h>
 #include <WAVM/Runtime/Runtime.h>
-#include <wavm/openmp/ThreadState.h>
+
+#include <wasm/WasmModule.h>
 
 using namespace WAVM;
 
@@ -17,6 +16,8 @@ namespace wasm {
     WAVM_DECLARE_INTRINSIC_MODULE(tsenv)
 
     struct WasmThreadSpec;
+
+    class PlatformThreadPool;
 
     class WAVMWasmModule : public WasmModule, Runtime::Resolver {
     public:
@@ -115,6 +116,8 @@ namespace wasm {
 
         U32 allocateThreadStack();
 
+        std::unique_ptr<PlatformThreadPool> &getPool();
+
     protected:
         void doSnapshot(std::ostream &outStream) override;
 
@@ -177,6 +180,8 @@ namespace wasm {
         void executeRemoteOMP(message::Message &msg);
 
         void prepareOpenMPContext(const message::Message &msg);
+
+        std::unique_ptr<PlatformThreadPool> ompPool;
     };
 
     WAVMWasmModule *getExecutingModule();

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <wasm/WasmModule.h>
+
 #include <WAVM/Runtime/Intrinsics.h>
 #include <WAVM/Runtime/Linker.h>
 #include <WAVM/Runtime/Runtime.h>
-
-#include <wasm/WasmModule.h>
 
 using namespace WAVM;
 

--- a/include/wavm/openmp/Level.h
+++ b/include/wavm/openmp/Level.h
@@ -31,13 +31,7 @@ namespace wasm {
             // TODO - This implementation limits to one lock for all critical sections at a level.
             // Mention in report (maybe fix looking at the lck address and doing a lookup on it though?)
             std::mutex criticalSection; // Mutex used in critical sections.
-#ifdef OMP_PTS
-            std::vector<std::uint32_t> stackTops; // Pre-allocated stacks for the level
-
-            Level(std::vector<std::uint32_t> &&stackTops) : stackTops(stackTops) {}
-#else
             Level() = default;
-#endif
 
             // Local constructor
             Level(const std::shared_ptr<Level> &parent, int num_threads);
@@ -61,12 +55,7 @@ namespace wasm {
         class SingleHostLevel : public Level {
         public:
 
-#ifdef OMP_PTS
-            SingleHostLevel(std::vector<std::uint32_t>&& stackTops) : Level(std::move(stackTops)) {}
-#else
-
             SingleHostLevel() = default;
-#endif
 
             SingleHostLevel(const std::shared_ptr<Level> &parent, int numThreads);
 

--- a/include/wavm/openmp/openmp.h
+++ b/include/wavm/openmp/openmp.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <wavm/openmp/Level.h>
+#include <wavm/WAVMWasmModule.h>
+
+namespace wasm {
+
+    namespace openmp {
+        struct LocalThreadArgs {
+            int tid = 0;
+            std::shared_ptr<Level> level = nullptr;
+            WAVMWasmModule *parentModule;
+            message::Message *parentCall;
+            WasmThreadSpec spec;
+        };
+    }
+
+}

--- a/src/wavm/CMakeLists.txt
+++ b/src/wavm/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(
 )
 
 set(HEADERS
+        "${FAASM_INCLUDE_DIR}/wavm/PlatformThreadPool.h"
         "${FAASM_INCLUDE_DIR}/wavm/WAVMWasmModule.h"
         )
 
@@ -24,6 +25,7 @@ set(LIB_FILES
         mpi.cpp
         network.cpp
         openmp.cpp
+        PlatformThreadPool.cpp
         process.cpp
         rust.cpp
         scheduling.cpp

--- a/src/wavm/PlatformThreadPool.cpp
+++ b/src/wavm/PlatformThreadPool.cpp
@@ -9,8 +9,6 @@ using namespace util;
 namespace wasm {
     using namespace openmp;
 
-//    I64 ompThreadEntryFunc(void *threadArgsPtr);
-
     I64 workerEntryFunc(void *_args) {
         auto args = reinterpret_cast<WorkerArgs *>(_args);
         U32 stackTop = args->stackTop;

--- a/src/wavm/PlatformThreadPool.cpp
+++ b/src/wavm/PlatformThreadPool.cpp
@@ -1,0 +1,82 @@
+#include "PlatformThreadPool.h"
+
+#include <wavm/openmp/ThreadState.h>
+#include <wavm/openmp/openmp.h>
+#include <wavm/WAVMWasmModule.h>
+
+using namespace util;
+
+namespace wasm {
+    using namespace openmp;
+
+//    I64 ompThreadEntryFunc(void *threadArgsPtr);
+
+    I64 workerEntryFunc(void *_args) {
+        auto args = reinterpret_cast<WorkerArgs *>(_args);
+        U32 stackTop = args->stackTop;
+        PlatformThreadPool *pool = args->pool;
+        delete args;
+
+        for (;;) {
+            std::promise<I64> promise;
+            LocalThreadArgs threadArgs;
+
+            {
+                UniqueLock lock(pool->mutexQueue);
+                pool->condition.wait(lock, [&pool] { return pool->stop || !pool->tasks.empty(); });
+                if (pool->stop && pool->tasks.empty()) {
+                    // We're done folks
+                    return 0;
+                }
+                auto pair = std::move(pool->tasks.front());
+                pool->tasks.pop();
+                promise = std::move(pair.first);
+                threadArgs = std::move(pair.second);
+            }
+
+            setTLS(threadArgs.tid, threadArgs.level);
+            setExecutingModule(threadArgs.parentModule);
+            setExecutingCall(threadArgs.parentCall);
+            threadArgs.spec.stackTop = stackTop;
+            promise.set_value(threadArgs.parentModule->executeThreadLocally(threadArgs.spec));
+        }
+    }
+
+    PlatformThreadPool::PlatformThreadPool(size_t numThreads, WAVMWasmModule *module) {
+        for (size_t i = 0; i < numThreads; ++i) {
+            // Set up workers arguments including pre-allocating a stack for the threads it will execute
+            WorkerArgs *workerArgs = new WorkerArgs();
+            workerArgs->stackTop = module->allocateThreadStack();
+            workerArgs->pool = this;
+
+            // Run worker
+            workers.emplace_back(Platform::createThread(0, workerEntryFunc, workerArgs));
+        }
+    }
+
+    std::future<I64> PlatformThreadPool::runThread(LocalThreadArgs &&threadArgs) {
+        // Workers pull promises to save futures in them.
+        std::promise<I64> promise;
+        std::future<I64> future = promise.get_future();
+
+        // Sends works to workers
+        {
+            UniqueLock lock(mutexQueue);
+            tasks.emplace(std::make_pair(std::move(promise), std::move(threadArgs)));
+        }
+
+        condition.notify_one();
+        return future;
+    }
+
+    PlatformThreadPool::~PlatformThreadPool() {
+        {
+            UniqueLock lock(mutexQueue);
+            stop = true;
+        }
+        condition.notify_all();
+        for (auto worker : workers) {
+            Platform::joinThread(worker);
+        }
+    }
+}

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -331,11 +331,8 @@ namespace wasm {
             // Set up new level
             auto nextLevel = std::make_shared<SingleHostLevel>(thisLevel, nextNumThreads);
 
-            // Note - must ensure thread arguments are outside loop scope otherwise they do
-            // may not exist by the time the thread actually consumes them
-//            std::vector<LocalThreadArgs> threadArgs;
-//            threadArgs.reserve(nextNumThreads);
-
+            // Safety - must ensure thread arguments lifetime is longer than the threads
+            // And that this container is not moved (reserve).
             std::vector<std::vector<IR::UntaggedValue>> microtaskArgs;
             microtaskArgs.reserve(nextNumThreads);
 

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -1,28 +1,22 @@
-#include "WAVMWasmModule.h"
+#include "wavm/openmp/openmp.h"
 
-#include <wavm/openmp/Level.h>
-#include <wavm/openmp/ThreadState.h>
-
+#include <future>
 #include <WAVM/Platform/Thread.h>
 #include <WAVM/Runtime/Runtime.h>
 #include <WAVM/Runtime/Intrinsics.h>
 
-#include <faasm/array.h>
 #include <state/StateKeyValue.h>
 #include <scheduler/Scheduler.h>
-
 #include <util/timing.h>
+#include <wavm/openmp/Level.h>
+#include <wavm/openmp/ThreadState.h>
+#include <wavm/PlatformThreadPool.h>
+#include <wavm/WAVMWasmModule.h>
+
 
 namespace wasm {
     using namespace openmp;
 
-    struct LocalThreadArgs {
-        int tid = 0;
-        std::shared_ptr<openmp::Level> level = nullptr;
-        wasm::WAVMWasmModule *parentModule;
-        message::Message *parentCall;
-        WasmThreadSpec spec;
-    };
     /**
      * Performs actual static assignment
      */
@@ -216,6 +210,7 @@ namespace wasm {
     static std::string activeSnapshotKey;
     static size_t threadSnapshotSize;
 
+    static std::atomic_int64_t num_threads = 0;
     /**
      * The "real" version of this function is implemented in the openmp source at
      * openmp/runtime/src/kmp_csupport.cpp. This in turn calls __kmp_fork_call which
@@ -250,6 +245,10 @@ namespace wasm {
         // Set up number of threads for next level
         int nextNumThreads = thisLevel->get_next_level_num_threads();
         pushedNumThreads = -1; // Resets for next push
+
+        num_threads.fetch_add(nextNumThreads);
+        logger->error("total num_threads {}, nnt {} at depth {}, ED {}", num_threads, nextNumThreads, thisLevel->depth,
+                      thisLevel->effectiveDepth);
 
         if (0 > userDefaultDevice) {
 
@@ -329,26 +328,19 @@ namespace wasm {
             logger->debug("Distributed Fork finished successfully");
         } else { // Single host
 
-#ifdef OMP_PTS
-            if (nextNumThreads > thisLevel->stackTops.size()) {
-                logger->error("OpenMP needs to allocate more initial stacks than configured max threads");
-                throw std::runtime_error("Too many asked OpenMP threads");
-            }
-#endif
-
             // Set up new level
             auto nextLevel = std::make_shared<SingleHostLevel>(thisLevel, nextNumThreads);
 
             // Note - must ensure thread arguments are outside loop scope otherwise they do
             // may not exist by the time the thread actually consumes them
-            std::vector<LocalThreadArgs> threadArgs;
-            threadArgs.reserve(nextNumThreads);
+//            std::vector<LocalThreadArgs> threadArgs;
+//            threadArgs.reserve(nextNumThreads);
 
             std::vector<std::vector<IR::UntaggedValue>> microtaskArgs;
             microtaskArgs.reserve(nextNumThreads);
 
-            std::vector<WAVM::Platform::Thread *> platformThreads;
-            platformThreads.reserve(nextNumThreads);
+            std::vector<std::future<I64>> threadsFutures;
+            threadsFutures.reserve(nextNumThreads);
 
             // Build up arguments
             for (int threadNum = 0; threadNum < nextNumThreads; threadNum++) {
@@ -365,37 +357,25 @@ namespace wasm {
 
                 // Arguments for spawning the thread
                 // NOTE - CLion auto-format insists on this layout... and clangd really hates C99 extensions
-                threadArgs.push_back({
-                                             .tid = threadNum,
-                                             .level = nextLevel,
-                                             .parentModule = parentModule,
-                                             .parentCall = parentCall,
-                                             .spec = {
-                                                     .contextRuntimeData = contextRuntimeData,
-                                                     .func = func,
-                                                     .funcArgs = microtaskArgs[threadNum].data(),
-#ifdef OMP_PTS
-                                                     .stackTop = thisLevel->stackTops.size() > 0 ? thisLevel->stackTops[threadNum] : parentModule->allocateThreadStack(),
-#else
-                                                     .stackTop = parentModule->allocateThreadStack(),
-#endif
-                                             }
-                                     });
-            }
+                LocalThreadArgs threadArgs = {
+                        .tid = threadNum,
+                        .level = nextLevel,
+                        .parentModule = parentModule,
+                        .parentCall = parentCall,
+                        .spec = {
+                                .contextRuntimeData = contextRuntimeData,
+                                .func = func,
+                                .funcArgs = microtaskArgs[threadNum].data(),
+                        }
+                };
 
-            // Create the threads themselves
-            for (int threadNum = 0; threadNum < nextNumThreads; threadNum++) {
-                platformThreads.emplace_back(Platform::createThread(
-                        0,
-                        ompThreadEntryFunc,
-                        &threadArgs[threadNum]
-                ));
+                threadsFutures.emplace_back(parentModule->getPool()->runThread(std::move(threadArgs)));
             }
 
             // Await all threads
             I64 numErrors = 0;
-            for (auto t: platformThreads) {
-                numErrors += Platform::joinThread(t);
+            for (auto &f : threadsFutures) {
+                numErrors += f.get();
             }
 
             if (numErrors) {


### PR DESCRIPTION
Good news there is a noticeable improvement in speed with this design, although not as lighting fast as native code I think we might only. It now takes 1s to run code that runs in .5s in native.
We can noticeably see that we have less parallel code:
```
time ~/LULESH/build/lulesh2.0 
             0.81user 0.10system 0:00.06elapsed 1395%CPU
time simple_runner lulesh lulesh_omp
             1.07user 1.30system 0:01.08elapsed 218%CPU 
```
Which `perf` agrees with (i'll need to see which mutex is the one with the contention, possibly the worker queue:
```
+   39.55%     0.50%  simple_runner  [kernel.kallsyms]    [k] entry_SYSCALL_64_after_hwframe
+   38.89%     4.58%  simple_runner  [kernel.kallsyms]    [k] do_syscall_64
+   22.70%     0.03%  simple_runner  [kernel.kallsyms]    [k] page_fault
+   22.66%     0.07%  simple_runner  [kernel.kallsyms]    [k] do_page_fault
+   22.55%     0.38%  simple_runner  [kernel.kallsyms]    [k] __do_page_fault
+   22.35%     0.21%  simple_runner  simple_runner        [.] wasm::WAVMWasmModule::executeThreadLocally
+   21.68%     0.47%  simple_runner  [kernel.kallsyms]    [k] sys_futex
+   21.20%     0.47%  simple_runner  [kernel.kallsyms]    [k] do_futex
+   20.27%     0.00%  simple_runner  libWAVM.so.0.0.0     [.] WAVM::Platform::initThreadAndGlobalSignalsOnce
+   20.25%     0.00%  simple_runner  libpthread-2.27.so   [.] start_thread
+   20.24%     0.00%  simple_runner  libWAVM.so.0.0.0     [.] createThreadEntry
+   20.22%     0.00%  simple_runner  libWAVM.so.0.0.0     [.] WAVM::Platform::SigAltStack::init
+   20.22%     0.88%  simple_runner  libWAVM.so.0.0.0     [.] touchStackPages
    16.34%     0.00%  simple_runner  [unknown]            [.] 0000000000000000
+   11.42%     0.57%  simple_runner  [kernel.kallsyms]    [k] futex_wait
+    9.09%     0.79%  simple_runner  [kernel.kallsyms]    [k] futex_wake
+    8.99%     0.47%  simple_runner  [kernel.kallsyms]    [k] handle_mm_fault
     8.87%     0.08%  simple_runner  libWAVM.so.0.0.0     [.] WAVM::Runtime::catchRuntimeExceptions
     8.80%     0.06%  simple_runner  libWAVM.so.0.0.0     [.] WAVM::Runtime::unwindSignalsAsExceptions
     8.33%     0.29%  simple_runner  [kernel.kallsyms]    [k] futex_wait_queue_me
+    8.27%     3.90%  simple_runner  [kernel.kallsyms]    [k] __handle_mm_fault
+    8.07%     0.10%  simple_runner  [kernel.kallsyms]    [k] schedule
+    7.89%     7.84%  simple_runner  [kernel.kallsyms]    [k] down_read_trylock
+    7.85%     0.47%  simple_runner  [kernel.kallsyms]    [k] __sched_text_start
     7.85%     0.17%  simple_runner  libWAVM.so.0.0.0     [.] WAVM::Runtime::invokeFunction
     7.66%     0.18%  simple_runner  libWAVM.so.0.0.0     [.] WAVM::Platform::catchSignals
+    7.20%     0.48%  simple_runner  libWAVM.so.0.0.0     [.] WAVM::Runtime::createContext
     7.13%     0.14%  simple_runner  simple_runner        [.] std::_Function_handler<void (), wasm::WAVMWasmModule::ex
+    6.74%     0.93%  simple_runner  libpthread-2.27.so   [.] pthread_cond_wait@@GLIBC_2.3.2
     6.24%     0.04%  simple_runner  libc-2.27.so         [.] __mmap
+    6.22%     1.82%  simple_runner  [kernel.kallsyms]    [k] try_to_wake_up
+    6.17%     0.13%  simple_runner  [kernel.kallsyms]    [k] wake_up_q
+    5.99%     0.11%  simple_runner  libc-2.27.so         [.] __mprotect
+    5.93%     0.88%  simple_runner  libc-2.27.so         [.] __memmove_avx_unaligned_erms
+    5.70%     0.05%  simple_runner  libpthread-2.27.so   [.] __lll_unlock_wake
     5.47%     0.61%  simple_runner  libpthread-2.27.so   [.] __pthread_rwlock_wrlock
     5.23%     0.04%  simple_runner  [kernel.kallsyms]    [k] sys_mmap_pgoff
     5.21%     0.00%  simple_runner  [kernel.kallsyms]    [k] sys_mmap
     5.19%     0.03%  simple_runner  [kernel.kallsyms]    [k] vm_mmap_pgoff
     5.03%     0.05%  simple_runner  [kernel.kallsyms]    [k] do_mmap
+    4.95%     0.06%  simple_runner  [kernel.kallsyms]    [k] sys_mprotect
     4.89%     0.46%  simple_runner  [kernel.kallsyms]    [k] mmap_region
```