### PR TITLE
No queue design

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,13 +38,9 @@
 [submodule "third-party/ParResKernels"]
 	path = third-party/ParResKernels
 	url = https://github.com/Shillaker/Kernels.git
-[submodule "third-party/LULESH"]
-	path = third-party/LULESH
-	url = https://github.com/mfournial/LULESH.git
 [submodule "third-party/wasi-libc"]
-    path = third-party/wasi-libc
-    url = https://github.com/Shillaker/wasi-libc
-
+	path = third-party/wasi-libc
+	url = https://github.com/Shillaker/wasi-libc
 [submodule "third-party/wamr"]
 	path = third-party/wamr
 	url = https://github.com/bytecodealliance/wasm-micro-runtime.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,10 @@ else ()
     endfunction()
 endif ()
 
-option(OMP_PTS "PREALLOCATE THREAD STACK: Only available for local WasmMP and non recursive levels" FALSE)
-if (OMP_PTS)
-    add_compile_definitions(-DOMP_PTS)
+option(FAASM_OMP_PTS "PREALLOCATE THREAD STACK: Only available for local WasmMP and non recursive levels")
+if (${FAASM_OMP_PTS})
+    message("-- Activated OMP_PTS: OpenMP Thread stack preallocation feature")
+    add_compile_definitions(OMP_PTS)
 endif ()
 
 # Switch on WAVM stack traces in debug (potential performance gain?)
@@ -69,11 +70,14 @@ add_definitions(-DDLL_EXPORT=)
 add_definitions(-DDLL_IMPORT=)
 
 # Faasm profiling
-add_definitions(-DFAASM_PROFILE_ON=0)
+option(FAASM_PERF_PROFILING "Turn on profiling features as described in debugging.md")
+option(FAASM_SELF_PROFILING "Turn on system profiling logged at tracing level")
 
-# Custom LLVM build (also for profiling)
-set(FAASM_CUSTOM_LLVM 0)
-if (${FAASM_CUSTOM_LLVM})
+if (${FAASM_SELF_PROFILING})
+    add_compile_definitions(PROFILE_ALL)
+endif ()
+
+if (${FAASM_PERF_PROFILING})
     # In accordance with bin/build_llvm_perf.sh and LLVM version for WAVM
     set(LLVM_DIR /usr/local/code/llvm-perf/build/lib/cmake/llvm)
     message(STATUS "Using custom LLVM at ${LLVM_DIR} for profiling")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if (FAASM_WAMR_SUPPORT)
     set(WAMR_BUILD_AOT 0)
     set(WAMR_BUILD_LIBC_WASI 1)
     set(WAMR_BUILD_LIBC_BUILTIN 0)
-endif()
+endif ()
 
 # Library type (for shared libraries)
 if (FAASM_STATIC_LIBS)
@@ -49,6 +49,11 @@ else ()
         add_library(${lib_name} STATIC ${lib_deps})
         target_compile_options(${lib_name} PRIVATE "-fPIC")
     endfunction()
+endif ()
+
+option(OMP_PTS "PREALLOCATE THREAD STACK: Only available for local WasmMP and non recursive levels" FALSE)
+if (OMP_PTS)
+    add_compile_definitions(-DOMP_PTS)
 endif ()
 
 # Switch on WAVM stack traces in debug (potential performance gain?)
@@ -143,10 +148,10 @@ else ()
     # WAVM
     add_subdirectory(third-party/WAVM)
 
-    if(FAASM_WAMR_SUPPORT)
-    include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
-    add_library(libwamr ${WAMR_RUNTIME_LIB_SOURCE})
-    endif()
+    if (FAASM_WAMR_SUPPORT)
+        include(${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
+        add_library(libwamr ${WAMR_RUNTIME_LIB_SOURCE})
+    endif ()
 
     # Faasm functions
     add_subdirectory(func)

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -5,8 +5,10 @@
 As Faasm functions are compiled to WebAssembly and executed using [WAVM](https://github.com/WAVM/WAVM/),
 any general tips that apply in WAVM also apply to Faasm.
 
-The instructions below assume that you're building Faasm locally as per the [local dev](local_dev.md) 
-instructions and that Faasm's built executables are on your `PATH`.
+The instructions below assume that 
+- you're building Faasm locally as per the [local dev](local_dev.md) instructions,
+- that you built the `func_sym` target,
+- that Faasm's built executables are on your `PATH`.
 
 ### Symbols
 
@@ -53,8 +55,8 @@ To set things up you need to do the following:
 
 - Run the `perf.yml` Ansible playbook to set up `perf`
 - Create a build of LLVM with perf support by running `./bin/build/llvm_perf` (this takes ages)
-- Modify the top-level `CMakeLists.txt` to set `FAASM_CUSTOM_LLVM` to `1`
-- Rebuild the target you want to profile
+- Turn on the `FAASM_PERF_PROFILING` option in you CMake build configuration. (`ccmake <build_dir>` makes this easy).
+- Rebuild `codegen_func`, and your runner to build and run the target you want to profile, 
 
 Once this is done you can use perf as described [here](https://lwn.net/Articles/633846/), i.e.:
 

--- a/faasmcli/faasmcli/tasks/libs.py
+++ b/faasmcli/faasmcli/tasks/libs.py
@@ -70,10 +70,11 @@ def _build_faasm_lib(dir_name, clean, verbose):
 
     clean_dir(build_dir, clean)
 
-    verbose_str = "VERBOSE=1" if verbose else ""
+    verbose_str = "-s" if verbose else ""
     build_cmd = [
         verbose_str,
         "cmake",
+        "-G Ninja"
         "-DFAASM_BUILD_TYPE=wasm",
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_TOOLCHAIN_FILE={}".format(FAASM_TOOLCHAIN_FILE),
@@ -87,14 +88,9 @@ def _build_faasm_lib(dir_name, clean, verbose):
     if res != 0:
         exit(1)
 
-    res = call("{} make".format(verbose_str), shell=True, cwd=build_dir)
+    res = call("ninja {} install".format(verbose_str), shell=True, cwd=build_dir)
     if res != 0:
         exit(1)
-
-    res = call("make install", shell=True, cwd=build_dir)
-    if res != 0:
-        exit(1)
-
 
 @task
 def faasm(ctx, clean=False, lib=None, verbose=False):
@@ -133,6 +129,30 @@ def rust(ctx, clean=False, verbose=False):
     Install Rust library
     """
     _build_faasm_lib("rust", clean, verbose)
+
+@task
+def malloc(ctx, clean=False):
+    """
+    Compile and install dlmalloc
+    """
+    work_dir = join(PROJ_ROOT, "third-party", "malloc")
+    build_dir = join(PROJ_ROOT, "build", "malloc")
+
+    clean_dir(build_dir, clean)
+
+    build_cmd = [
+        "cmake",
+        "-G Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_TOOLCHAIN_FILE={}".format(FAASM_TOOLCHAIN_FILE),
+        work_dir,
+    ]
+
+    build_cmd_str = " ".join(build_cmd)
+    print(build_cmd_str)
+
+    call(build_cmd_str, shell=True, cwd=build_dir)
+    call("ninja install", shell=True, cwd=build_dir)
 
 
 @task

--- a/faasmcli/faasmcli/tasks/libs.py
+++ b/faasmcli/faasmcli/tasks/libs.py
@@ -201,11 +201,11 @@ def fake(ctx, clean=False):
 
 
 @task
-def lulesh(ctx, mpi=False, omp=False, clean=True, debug=False, cp=True):
+def lulesh(ctx, lulesh_dir, mpi=False, omp=False, clean=True, debug=False, cp=True):
     """
     Compile and install the LULESH code
     """
-    work_dir = join(THIRD_PARTY_DIR, "LULESH")
+    work_dir = lulesh_dir
 
     if omp and mpi:
         build_dir = "ompi"

--- a/include/util/timing.h
+++ b/include/util/timing.h
@@ -3,7 +3,7 @@
 #include <util/clock.h>
 #include <string>
 
-#ifdef FAASM_PROFILE_ON
+#ifdef PROFILE_ALL
 #define PROF_START(name) const util::TimePoint name = util::startTimer();
 #define PROF_END(name) util::logEndTimer(#name, name);
 #else

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -115,9 +115,7 @@ namespace wasm {
         virtual void doRestore(std::istream &inStream) = 0;
 
         void prepareArgcArgv(const message::Message &msg);
-
-        void prepareOpenMPContext(const message::Message &msg);
-};
+    };
 
     // ----- Global functions -----
     message::Message *getExecutingCall();

--- a/include/wavm/PlatformThreadPool.h
+++ b/include/wavm/PlatformThreadPool.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+#include <WAVM/Runtime/Runtime.h>
+#include <WAVM/Inline/BasicTypes.h>
+#include <WAVM/Platform/Thread.h>
+
+#include <util/locks.h>
+#include <util/locks.h>
+#include <wavm/PlatformThreadPool.h>
+
+namespace wasm {
+
+    using namespace WAVM;
+    class WAVMWasmModule;
+
+    namespace openmp {
+        struct LocalThreadArgs;
+    }
+
+    class PlatformThreadPool {
+    public:
+        PlatformThreadPool(size_t numThreads, WAVMWasmModule *module);
+
+        friend I64 workerEntryFunc(void* _args);
+
+        std::future<I64> runThread(openmp::LocalThreadArgs &&threadArgs);
+
+        ~PlatformThreadPool();
+
+    private:
+        std::queue<std::pair<std::promise<I64>, openmp::LocalThreadArgs>> tasks;
+        std::vector<WAVM::Platform::Thread *> workers;
+
+        std::mutex mutexQueue;
+        std::condition_variable condition;
+        bool stop = false;
+    };
+
+    struct WorkerArgs {
+        U32 stackTop;
+        PlatformThreadPool *pool;
+    };
+
+}
+

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <wasm/WasmModule.h>
-
 #include <WAVM/Runtime/Intrinsics.h>
 #include <WAVM/Runtime/Linker.h>
 #include <WAVM/Runtime/Runtime.h>
-#include <wavm/openmp/ThreadState.h>
+
+#include <wasm/WasmModule.h>
 
 using namespace WAVM;
 
@@ -17,6 +16,8 @@ namespace wasm {
     WAVM_DECLARE_INTRINSIC_MODULE(tsenv)
 
     struct WasmThreadSpec;
+
+    class PlatformThreadPool;
 
     class WAVMWasmModule : public WasmModule, Runtime::Resolver {
     public:
@@ -115,6 +116,8 @@ namespace wasm {
 
         U32 allocateThreadStack();
 
+        std::unique_ptr<PlatformThreadPool> &getPool();
+
     protected:
         void doSnapshot(std::ostream &outStream) override;
 
@@ -177,6 +180,8 @@ namespace wasm {
         void executeRemoteOMP(message::Message &msg);
 
         void prepareOpenMPContext(const message::Message &msg);
+
+        std::unique_ptr<PlatformThreadPool> ompPool;
     };
 
     WAVMWasmModule *getExecutingModule();

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -5,6 +5,7 @@
 #include <WAVM/Runtime/Intrinsics.h>
 #include <WAVM/Runtime/Linker.h>
 #include <WAVM/Runtime/Runtime.h>
+#include <wavm/openmp/ThreadState.h>
 
 using namespace WAVM;
 
@@ -112,6 +113,8 @@ namespace wasm {
 
         int getDataOffsetFromGOT(const std::string &name);
 
+        U32 allocateThreadStack();
+
     protected:
         void doSnapshot(std::ostream &outStream) override;
 
@@ -172,6 +175,8 @@ namespace wasm {
         void syncPythonFunctionFile(const message::Message &msg);
 
         void executeRemoteOMP(message::Message &msg);
+
+        void prepareOpenMPContext(const message::Message &msg);
     };
 
     WAVMWasmModule *getExecutingModule();
@@ -182,5 +187,6 @@ namespace wasm {
         Runtime::ContextRuntimeData *contextRuntimeData;
         Runtime::Function *func;
         IR::UntaggedValue *funcArgs;
+        U32 stackTop;
     };
 }

--- a/include/wavm/openmp/Level.h
+++ b/include/wavm/openmp/Level.h
@@ -31,13 +31,7 @@ namespace wasm {
             // TODO - This implementation limits to one lock for all critical sections at a level.
             // Mention in report (maybe fix looking at the lck address and doing a lookup on it though?)
             std::mutex criticalSection; // Mutex used in critical sections.
-#ifdef OMP_PTS
-            std::vector<std::uint32_t> stackTops; // Pre-allocated stacks for the level
-
-            Level(std::vector<std::uint32_t> &&stackTops) : stackTops(stackTops) {}
-#else
             Level() = default;
-#endif
 
             // Local constructor
             Level(const std::shared_ptr<Level> &parent, int num_threads);
@@ -61,12 +55,7 @@ namespace wasm {
         class SingleHostLevel : public Level {
         public:
 
-#ifdef OMP_PTS
-            SingleHostLevel(std::vector<std::uint32_t>&& stackTops) : Level(std::move(stackTops)) {}
-#else
-
             SingleHostLevel() = default;
-#endif
 
             SingleHostLevel(const std::shared_ptr<Level> &parent, int numThreads);
 

--- a/include/wavm/openmp/Level.h
+++ b/include/wavm/openmp/Level.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <wavm/openmp/ClangTypes.h>
 #include <mutex>
+
 #include <proto/faasm.pb.h>
 #include <util/barrier.h>
 #include <util/environment.h>
+#include <wavm/openmp/ClangTypes.h>
 
 namespace wasm {
     namespace openmp {
@@ -20,6 +21,7 @@ namespace wasm {
         // Global variables controlled by level master
         class Level {
         public:
+            // Defaults set to mimic Clang 9.0.1 behaviour
             const int depth = 0; // Number of nested OpenMP constructs, 0 for serial code
             const int effectiveDepth = 0; // Number of parallel regions (> 1 thread) above this level
             int maxActiveLevel = 1; // Max number of effective parallel regions allowed from the top
@@ -29,9 +31,13 @@ namespace wasm {
             // TODO - This implementation limits to one lock for all critical sections at a level.
             // Mention in report (maybe fix looking at the lck address and doing a lookup on it though?)
             std::mutex criticalSection; // Mutex used in critical sections.
+#ifdef OMP_PTS
+            std::vector<std::uint32_t> stackTops; // Pre-allocated stacks for the level
 
-            // Defaults set to mimic Clang 9.0.1 behaviour
+            Level(std::vector<std::uint32_t> &&stackTops) : stackTops(stackTops) {}
+#else
             Level() = default;
+#endif
 
             // Local constructor
             Level(const std::shared_ptr<Level> &parent, int num_threads);
@@ -54,9 +60,16 @@ namespace wasm {
 
         class SingleHostLevel : public Level {
         public:
-            SingleHostLevel() = default;
 
-            SingleHostLevel(const std::shared_ptr<Level>& parent, int numThreads);
+#ifdef OMP_PTS
+            SingleHostLevel(std::vector<std::uint32_t>&& stackTops) : Level(std::move(stackTops)) {}
+#else
+
+            SingleHostLevel() = default;
+#endif
+
+            SingleHostLevel(const std::shared_ptr<Level> &parent, int numThreads);
+
             ReduceTypes reductionMethod() override;
 
             ~SingleHostLevel() = default;

--- a/include/wavm/openmp/openmp.h
+++ b/include/wavm/openmp/openmp.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <wavm/openmp/Level.h>
+#include <wavm/WAVMWasmModule.h>
+
+namespace wasm {
+
+    namespace openmp {
+        struct LocalThreadArgs {
+            int tid = 0;
+            std::shared_ptr<Level> level = nullptr;
+            WAVMWasmModule *parentModule;
+            message::Message *parentCall;
+            WasmThreadSpec spec;
+        };
+    }
+
+}

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -6,7 +6,6 @@
 #include <util/func.h>
 #include <util/locks.h>
 #include <sys/uio.h>
-#include <wavm/openmp/ThreadState.h>
 
 #include <boost/filesystem.hpp>
 #include <sstream>
@@ -192,23 +191,6 @@ namespace wasm {
         for (const auto &thisArg : argv) {
             argvBufferSize += thisArg.size() + 1;
         }
-    }
-
-    void WasmModule::prepareOpenMPContext(const message::Message &msg) {
-        std::shared_ptr<openmp::Level> ompLevel;
-
-        if (msg.has_ompdepth()) {
-            ompLevel = std::static_pointer_cast<openmp::Level>(
-                    std::make_shared<openmp::MultiHostSumLevel>(msg.ompdepth(),
-                                                                msg.ompeffdepth(),
-                                                                msg.ompmal(),
-                                                                msg.ompnumthreads()));
-        } else {
-            ompLevel = std::static_pointer_cast<openmp::Level>(
-                    std::make_shared<openmp::SingleHostLevel>());
-        }
-
-        openmp::setTLS(msg.ompthreadnum(), ompLevel);
     }
 
 }

--- a/src/wavm/CMakeLists.txt
+++ b/src/wavm/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(
 )
 
 set(HEADERS
+        "${FAASM_INCLUDE_DIR}/wavm/PlatformThreadPool.h"
         "${FAASM_INCLUDE_DIR}/wavm/WAVMWasmModule.h"
         )
 
@@ -24,6 +25,7 @@ set(LIB_FILES
         mpi.cpp
         network.cpp
         openmp.cpp
+        PlatformThreadPool.cpp
         process.cpp
         rust.cpp
         scheduling.cpp

--- a/src/wavm/PlatformThreadPool.cpp
+++ b/src/wavm/PlatformThreadPool.cpp
@@ -1,0 +1,82 @@
+#include "PlatformThreadPool.h"
+
+#include <wavm/openmp/ThreadState.h>
+#include <wavm/openmp/openmp.h>
+#include <wavm/WAVMWasmModule.h>
+
+using namespace util;
+
+namespace wasm {
+    using namespace openmp;
+
+//    I64 ompThreadEntryFunc(void *threadArgsPtr);
+
+    I64 workerEntryFunc(void *_args) {
+        auto args = reinterpret_cast<WorkerArgs *>(_args);
+        U32 stackTop = args->stackTop;
+        PlatformThreadPool *pool = args->pool;
+        delete args;
+
+        for (;;) {
+            std::promise<I64> promise;
+            LocalThreadArgs threadArgs;
+
+            {
+                UniqueLock lock(pool->mutexQueue);
+                pool->condition.wait(lock, [&pool] { return pool->stop || !pool->tasks.empty(); });
+                if (pool->stop && pool->tasks.empty()) {
+                    // We're done folks
+                    return 0;
+                }
+                auto pair = std::move(pool->tasks.front());
+                pool->tasks.pop();
+                promise = std::move(pair.first);
+                threadArgs = std::move(pair.second);
+            }
+
+            setTLS(threadArgs.tid, threadArgs.level);
+            setExecutingModule(threadArgs.parentModule);
+            setExecutingCall(threadArgs.parentCall);
+            threadArgs.spec.stackTop = stackTop;
+            promise.set_value(threadArgs.parentModule->executeThreadLocally(threadArgs.spec));
+        }
+    }
+
+    PlatformThreadPool::PlatformThreadPool(size_t numThreads, WAVMWasmModule *module) {
+        for (size_t i = 0; i < numThreads; ++i) {
+            // Set up workers arguments including pre-allocating a stack for the threads it will execute
+            WorkerArgs *workerArgs = new WorkerArgs();
+            workerArgs->stackTop = module->allocateThreadStack();
+            workerArgs->pool = this;
+
+            // Run worker
+            workers.emplace_back(Platform::createThread(0, workerEntryFunc, workerArgs));
+        }
+    }
+
+    std::future<I64> PlatformThreadPool::runThread(LocalThreadArgs &&threadArgs) {
+        // Workers pull promises to save futures in them.
+        std::promise<I64> promise;
+        std::future<I64> future = promise.get_future();
+
+        // Sends works to workers
+        {
+            UniqueLock lock(mutexQueue);
+            tasks.emplace(std::make_pair(std::move(promise), std::move(threadArgs)));
+        }
+
+        condition.notify_one();
+        return future;
+    }
+
+    PlatformThreadPool::~PlatformThreadPool() {
+        {
+            UniqueLock lock(mutexQueue);
+            stop = true;
+        }
+        condition.notify_all();
+        for (auto worker : workers) {
+            Platform::joinThread(worker);
+        }
+    }
+}

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -329,6 +329,13 @@ namespace wasm {
             logger->debug("Distributed Fork finished successfully");
         } else { // Single host
 
+#ifdef OMP_PTS
+            if (nextNumThreads > thisLevel->stackTops.size()) {
+                logger->error("OpenMP needs to allocate more initial stacks than configured max threads");
+                throw std::runtime_error("Too many asked OpenMP threads");
+            }
+#endif
+
             // Set up new level
             auto nextLevel = std::make_shared<SingleHostLevel>(thisLevel, nextNumThreads);
 
@@ -367,6 +374,11 @@ namespace wasm {
                                                      .contextRuntimeData = contextRuntimeData,
                                                      .func = func,
                                                      .funcArgs = microtaskArgs[threadNum].data(),
+#ifdef OMP_PTS
+                                                     .stackTop = thisLevel->stackTops.size() > 0 ? thisLevel->stackTops[threadNum] : parentModule->allocateThreadStack(),
+#else
+                                                     .stackTop = parentModule->allocateThreadStack(),
+#endif
                                              }
                                      });
             }

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -1,28 +1,22 @@
-#include "WAVMWasmModule.h"
+#include "wavm/openmp/openmp.h"
 
-#include <wavm/openmp/Level.h>
-#include <wavm/openmp/ThreadState.h>
-
+#include <future>
 #include <WAVM/Platform/Thread.h>
 #include <WAVM/Runtime/Runtime.h>
 #include <WAVM/Runtime/Intrinsics.h>
 
-#include <faasm/array.h>
 #include <state/StateKeyValue.h>
 #include <scheduler/Scheduler.h>
-
 #include <util/timing.h>
+#include <wavm/openmp/Level.h>
+#include <wavm/openmp/ThreadState.h>
+#include <wavm/PlatformThreadPool.h>
+#include <wavm/WAVMWasmModule.h>
+
 
 namespace wasm {
     using namespace openmp;
 
-    struct LocalThreadArgs {
-        int tid = 0;
-        std::shared_ptr<openmp::Level> level = nullptr;
-        wasm::WAVMWasmModule *parentModule;
-        message::Message *parentCall;
-        WasmThreadSpec spec;
-    };
     /**
      * Performs actual static assignment
      */
@@ -216,6 +210,7 @@ namespace wasm {
     static std::string activeSnapshotKey;
     static size_t threadSnapshotSize;
 
+    static std::atomic_int64_t num_threads = 0;
     /**
      * The "real" version of this function is implemented in the openmp source at
      * openmp/runtime/src/kmp_csupport.cpp. This in turn calls __kmp_fork_call which
@@ -250,6 +245,10 @@ namespace wasm {
         // Set up number of threads for next level
         int nextNumThreads = thisLevel->get_next_level_num_threads();
         pushedNumThreads = -1; // Resets for next push
+
+        num_threads.fetch_add(nextNumThreads);
+        logger->error("total num_threads {}, nnt {} at depth {}, ED {}", num_threads, nextNumThreads, thisLevel->depth,
+                      thisLevel->effectiveDepth);
 
         if (0 > userDefaultDevice) {
 
@@ -329,26 +328,19 @@ namespace wasm {
             logger->debug("Distributed Fork finished successfully");
         } else { // Single host
 
-#ifdef OMP_PTS
-            if (nextNumThreads > thisLevel->stackTops.size()) {
-                logger->error("OpenMP needs to allocate more initial stacks than configured max threads");
-                throw std::runtime_error("Too many asked OpenMP threads");
-            }
-#endif
-
             // Set up new level
             auto nextLevel = std::make_shared<SingleHostLevel>(thisLevel, nextNumThreads);
 
             // Note - must ensure thread arguments are outside loop scope otherwise they do
             // may not exist by the time the thread actually consumes them
-            std::vector<LocalThreadArgs> threadArgs;
-            threadArgs.reserve(nextNumThreads);
+//            std::vector<LocalThreadArgs> threadArgs;
+//            threadArgs.reserve(nextNumThreads);
 
             std::vector<std::vector<IR::UntaggedValue>> microtaskArgs;
             microtaskArgs.reserve(nextNumThreads);
 
-            std::vector<WAVM::Platform::Thread *> platformThreads;
-            platformThreads.reserve(nextNumThreads);
+            std::vector<std::future<I64>> threadsFutures;
+            threadsFutures.reserve(nextNumThreads);
 
             // Build up arguments
             for (int threadNum = 0; threadNum < nextNumThreads; threadNum++) {
@@ -365,37 +357,25 @@ namespace wasm {
 
                 // Arguments for spawning the thread
                 // NOTE - CLion auto-format insists on this layout... and clangd really hates C99 extensions
-                threadArgs.push_back({
-                                             .tid = threadNum,
-                                             .level = nextLevel,
-                                             .parentModule = parentModule,
-                                             .parentCall = parentCall,
-                                             .spec = {
-                                                     .contextRuntimeData = contextRuntimeData,
-                                                     .func = func,
-                                                     .funcArgs = microtaskArgs[threadNum].data(),
-#ifdef OMP_PTS
-                                                     .stackTop = thisLevel->stackTops.size() > 0 ? thisLevel->stackTops[threadNum] : parentModule->allocateThreadStack(),
-#else
-                                                     .stackTop = parentModule->allocateThreadStack(),
-#endif
-                                             }
-                                     });
-            }
+                LocalThreadArgs threadArgs = {
+                        .tid = threadNum,
+                        .level = nextLevel,
+                        .parentModule = parentModule,
+                        .parentCall = parentCall,
+                        .spec = {
+                                .contextRuntimeData = contextRuntimeData,
+                                .func = func,
+                                .funcArgs = microtaskArgs[threadNum].data(),
+                        }
+                };
 
-            // Create the threads themselves
-            for (int threadNum = 0; threadNum < nextNumThreads; threadNum++) {
-                platformThreads.emplace_back(Platform::createThread(
-                        0,
-                        ompThreadEntryFunc,
-                        &threadArgs[threadNum]
-                ));
+                threadsFutures.emplace_back(parentModule->getPool()->runThread(std::move(threadArgs)));
             }
 
             // Await all threads
             I64 numErrors = 0;
-            for (auto t: platformThreads) {
-                numErrors += Platform::joinThread(t);
+            for (auto &f : threadsFutures) {
+                numErrors += f.get();
             }
 
             if (numErrors) {

--- a/src/wavm/openmp/Level.cpp
+++ b/src/wavm/openmp/Level.cpp
@@ -1,4 +1,4 @@
-#include <wavm/openmp/Level.h>
+#include "wavm/openmp/Level.h"
 
 #include <openmp/ThreadState.h>
 #include <util/config.h>

--- a/src/wavm/threads.cpp
+++ b/src/wavm/threads.cpp
@@ -85,6 +85,7 @@ namespace wasm {
             spec->contextRuntimeData = contextRuntimeData;
             spec->func = func;
             spec->funcArgs = threadArgs;
+            spec->stackTop = thisModule->allocateThreadStack();
 
             auto pArgs = new PThreadArgs();
             pArgs->parentModule = thisModule;

--- a/third-party/malloc/CMakeLists.txt
+++ b/third-party/malloc/CMakeLists.txt
@@ -10,8 +10,8 @@ add_library(dlmalloc STATIC dlmalloc.c)
 set_target_properties(dlmalloc PROPERTIES PUBLIC_HEADER malloc.h)
 
 install(TARGETS dlmalloc
-        ARCHIVE DESTINATION ${CMAKE_SYSROOT}/lib
-        LIBRARY DESTINATION ${CMAKE_SYSROOT}/lib
+        ARCHIVE DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
+        LIBRARY DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
         RUNTIME DESTINATION ${CMAKE_SYSROOT}/bin
         PUBLIC_HEADER DESTINATION ${CMAKE_SYSROOT}/include/
         )


### PR DESCRIPTION
Trying to minimize the contention on the queue I came up with this design. It is 2x slower than the queue design, in its current shape, and also with the following modifications:
1. take lvalue instead of rvalue in `run` and save a pointer to the `LocalThreadArgs` in the class
1. Instead of a global mutex, make a mutex per thread on thread creation so the thread can self regulate (and count on memory ordering to safely modify shared variables `stop` and `runNumber`) 

It seems that this design is flawed, I'm opening this just in case I want to roll back quickly to it