### PR TITLE
Queue-free design

### DIFF
--- a/include/wavm/PlatformThreadPool.h
+++ b/include/wavm/PlatformThreadPool.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+#include <WAVM/Runtime/Runtime.h>
+#include <WAVM/Inline/BasicTypes.h>
+#include <WAVM/Platform/Thread.h>
+
+#include <util/locks.h>
+#include <util/locks.h>
+#include <wavm/PlatformThreadPool.h>
+
+namespace wasm {
+
+    using namespace WAVM;
+    class WAVMWasmModule;
+
+    namespace openmp {
+        struct LocalThreadArgs;
+    }
+
+    class PlatformThreadPool {
+    public:
+        PlatformThreadPool(size_t numThreads, WAVMWasmModule *module);
+
+        friend I64 workerEntryFunc(void* _args);
+
+        std::future<I64> runThread(openmp::LocalThreadArgs &&threadArgs);
+
+        ~PlatformThreadPool();
+
+    private:
+        std::queue<std::pair<std::promise<I64>, openmp::LocalThreadArgs>> tasks;
+        std::vector<WAVM::Platform::Thread *> workers;
+
+        std::mutex mutexQueue;
+        std::condition_variable condition;
+        bool stop = false;
+    };
+
+    struct WorkerArgs {
+        U32 stackTop;
+        PlatformThreadPool *pool;
+    };
+
+}
+

--- a/include/wavm/PlatformThreadPool.h
+++ b/include/wavm/PlatformThreadPool.h
@@ -17,6 +17,7 @@
 namespace wasm {
 
     using namespace WAVM;
+
     class WAVMWasmModule;
 
     namespace openmp {
@@ -29,22 +30,27 @@ namespace wasm {
 
         friend I64 workerEntryFunc(void* _args);
 
-        std::future<I64> runThread(openmp::LocalThreadArgs &&threadArgs);
+        std::vector<std::future<I64>> run(std::vector<openmp::LocalThreadArgs> &&threadArgs);
+
+        void clearPromises();
 
         ~PlatformThreadPool();
 
     private:
-        std::queue<std::pair<std::promise<I64>, openmp::LocalThreadArgs>> tasks;
-        std::vector<WAVM::Platform::Thread *> workers;
-
-        std::mutex mutexQueue;
+        std::vector<openmp::LocalThreadArgs> workerArgs;
+        std::vector<std::promise<I64>> promises;
+        std::mutex mutex;
         std::condition_variable condition;
+        std::uint32_t runNumber = 0;
+        std::vector<WAVM::Platform::Thread *> workers;
         bool stop = false;
+
     };
 
     struct WorkerArgs {
         U32 stackTop;
         PlatformThreadPool *pool;
+        size_t workerIdx;
     };
 
 }

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <wasm/WasmModule.h>
-
 #include <WAVM/Runtime/Intrinsics.h>
 #include <WAVM/Runtime/Linker.h>
 #include <WAVM/Runtime/Runtime.h>
-#include <wavm/openmp/ThreadState.h>
+
+#include <wasm/WasmModule.h>
 
 using namespace WAVM;
 
@@ -17,6 +16,8 @@ namespace wasm {
     WAVM_DECLARE_INTRINSIC_MODULE(tsenv)
 
     struct WasmThreadSpec;
+
+    class PlatformThreadPool;
 
     class WAVMWasmModule : public WasmModule, Runtime::Resolver {
     public:
@@ -115,6 +116,8 @@ namespace wasm {
 
         U32 allocateThreadStack();
 
+        std::unique_ptr<PlatformThreadPool> &getPool();
+
     protected:
         void doSnapshot(std::ostream &outStream) override;
 
@@ -177,6 +180,8 @@ namespace wasm {
         void executeRemoteOMP(message::Message &msg);
 
         void prepareOpenMPContext(const message::Message &msg);
+
+        std::unique_ptr<PlatformThreadPool> ompPool;
     };
 
     WAVMWasmModule *getExecutingModule();

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -116,7 +116,7 @@ namespace wasm {
 
         U32 allocateThreadStack();
 
-        std::unique_ptr<PlatformThreadPool> &getPool();
+        PlatformThreadPool &getPool();
 
     protected:
         void doSnapshot(std::ostream &outStream) override;

--- a/include/wavm/openmp/Level.h
+++ b/include/wavm/openmp/Level.h
@@ -31,13 +31,7 @@ namespace wasm {
             // TODO - This implementation limits to one lock for all critical sections at a level.
             // Mention in report (maybe fix looking at the lck address and doing a lookup on it though?)
             std::mutex criticalSection; // Mutex used in critical sections.
-#ifdef OMP_PTS
-            std::vector<std::uint32_t> stackTops; // Pre-allocated stacks for the level
-
-            Level(std::vector<std::uint32_t> &&stackTops) : stackTops(stackTops) {}
-#else
             Level() = default;
-#endif
 
             // Local constructor
             Level(const std::shared_ptr<Level> &parent, int num_threads);
@@ -61,12 +55,7 @@ namespace wasm {
         class SingleHostLevel : public Level {
         public:
 
-#ifdef OMP_PTS
-            SingleHostLevel(std::vector<std::uint32_t>&& stackTops) : Level(std::move(stackTops)) {}
-#else
-
             SingleHostLevel() = default;
-#endif
 
             SingleHostLevel(const std::shared_ptr<Level> &parent, int numThreads);
 

--- a/include/wavm/openmp/openmp.h
+++ b/include/wavm/openmp/openmp.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <wavm/openmp/Level.h>
+#include <wavm/WAVMWasmModule.h>
+
+namespace wasm {
+
+    namespace openmp {
+        struct LocalThreadArgs {
+            int tid = 0;
+            std::shared_ptr<Level> level = nullptr;
+            WAVMWasmModule *parentModule;
+            message::Message *parentCall;
+            WasmThreadSpec spec;
+        };
+    }
+
+}

--- a/src/wavm/CMakeLists.txt
+++ b/src/wavm/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(
 )
 
 set(HEADERS
+        "${FAASM_INCLUDE_DIR}/wavm/PlatformThreadPool.h"
         "${FAASM_INCLUDE_DIR}/wavm/WAVMWasmModule.h"
         )
 
@@ -24,6 +25,7 @@ set(LIB_FILES
         mpi.cpp
         network.cpp
         openmp.cpp
+        PlatformThreadPool.cpp
         process.cpp
         rust.cpp
         scheduling.cpp

--- a/src/wavm/PlatformThreadPool.cpp
+++ b/src/wavm/PlatformThreadPool.cpp
@@ -1,0 +1,82 @@
+#include "PlatformThreadPool.h"
+
+#include <wavm/openmp/ThreadState.h>
+#include <wavm/openmp/openmp.h>
+#include <wavm/WAVMWasmModule.h>
+
+using namespace util;
+
+namespace wasm {
+    using namespace openmp;
+
+//    I64 ompThreadEntryFunc(void *threadArgsPtr);
+
+    I64 workerEntryFunc(void *_args) {
+        auto args = reinterpret_cast<WorkerArgs *>(_args);
+        U32 stackTop = args->stackTop;
+        PlatformThreadPool *pool = args->pool;
+        delete args;
+
+        for (;;) {
+            std::promise<I64> promise;
+            LocalThreadArgs threadArgs;
+
+            {
+                UniqueLock lock(pool->mutexQueue);
+                pool->condition.wait(lock, [&pool] { return pool->stop || !pool->tasks.empty(); });
+                if (pool->stop && pool->tasks.empty()) {
+                    // We're done folks
+                    return 0;
+                }
+                auto pair = std::move(pool->tasks.front());
+                pool->tasks.pop();
+                promise = std::move(pair.first);
+                threadArgs = std::move(pair.second);
+            }
+
+            setTLS(threadArgs.tid, threadArgs.level);
+            setExecutingModule(threadArgs.parentModule);
+            setExecutingCall(threadArgs.parentCall);
+            threadArgs.spec.stackTop = stackTop;
+            promise.set_value(threadArgs.parentModule->executeThreadLocally(threadArgs.spec));
+        }
+    }
+
+    PlatformThreadPool::PlatformThreadPool(size_t numThreads, WAVMWasmModule *module) {
+        for (size_t i = 0; i < numThreads; ++i) {
+            // Set up workers arguments including pre-allocating a stack for the threads it will execute
+            WorkerArgs *workerArgs = new WorkerArgs();
+            workerArgs->stackTop = module->allocateThreadStack();
+            workerArgs->pool = this;
+
+            // Run worker
+            workers.emplace_back(Platform::createThread(0, workerEntryFunc, workerArgs));
+        }
+    }
+
+    std::future<I64> PlatformThreadPool::runThread(LocalThreadArgs &&threadArgs) {
+        // Workers pull promises to save futures in them.
+        std::promise<I64> promise;
+        std::future<I64> future = promise.get_future();
+
+        // Sends works to workers
+        {
+            UniqueLock lock(mutexQueue);
+            tasks.emplace(std::make_pair(std::move(promise), std::move(threadArgs)));
+        }
+
+        condition.notify_one();
+        return future;
+    }
+
+    PlatformThreadPool::~PlatformThreadPool() {
+        {
+            UniqueLock lock(mutexQueue);
+            stop = true;
+        }
+        condition.notify_all();
+        for (auto worker : workers) {
+            Platform::joinThread(worker);
+        }
+    }
+}

--- a/src/wavm/PlatformThreadPool.cpp
+++ b/src/wavm/PlatformThreadPool.cpp
@@ -3,6 +3,7 @@
 #include <wavm/openmp/ThreadState.h>
 #include <wavm/openmp/openmp.h>
 #include <wavm/WAVMWasmModule.h>
+#include <util/logging.h>
 
 using namespace util;
 
@@ -15,63 +16,78 @@ namespace wasm {
         auto args = reinterpret_cast<WorkerArgs *>(_args);
         U32 stackTop = args->stackTop;
         PlatformThreadPool *pool = args->pool;
+        size_t workerIdx = args->workerIdx;
         delete args;
+        std::uint32_t runNumber = 0;
 
         for (;;) {
-            std::promise<I64> promise;
-            LocalThreadArgs threadArgs;
 
             {
-                UniqueLock lock(pool->mutexQueue);
-                pool->condition.wait(lock, [&pool] { return pool->stop || !pool->tasks.empty(); });
-                if (pool->stop && pool->tasks.empty()) {
+                UniqueLock lock(pool->mutex);
+                pool->condition.wait(lock, [&pool, runNumber] { return pool->stop || pool->runNumber > runNumber; });
+                if (pool->stop) {
                     // We're done folks
                     return 0;
                 }
-                auto pair = std::move(pool->tasks.front());
-                pool->tasks.pop();
-                promise = std::move(pair.first);
-                threadArgs = std::move(pair.second);
             }
 
+            std::promise<I64> &promise = pool->promises[workerIdx];
+            LocalThreadArgs threadArgs = pool->workerArgs[workerIdx];
+
+            // Set up TLS
             setTLS(threadArgs.tid, threadArgs.level);
             setExecutingModule(threadArgs.parentModule);
             setExecutingCall(threadArgs.parentCall);
+
+            // Use preallocated stack
             threadArgs.spec.stackTop = stackTop;
+
+            // Run
             promise.set_value(threadArgs.parentModule->executeThreadLocally(threadArgs.spec));
+
+            // Wait for next job to come in
+            runNumber++;
         }
     }
 
     PlatformThreadPool::PlatformThreadPool(size_t numThreads, WAVMWasmModule *module) {
-        for (size_t i = 0; i < numThreads; ++i) {
+        promises.reserve(numThreads);
+        for (size_t i = 0; i < numThreads; i++) {
             // Set up workers arguments including pre-allocating a stack for the threads it will execute
-            WorkerArgs *workerArgs = new WorkerArgs();
-            workerArgs->stackTop = module->allocateThreadStack();
-            workerArgs->pool = this;
+            WorkerArgs *args = new WorkerArgs();
+            args->stackTop = module->allocateThreadStack();
+            args->pool = this;
+            args->workerIdx = i;
 
             // Run worker
-            workers.emplace_back(Platform::createThread(0, workerEntryFunc, workerArgs));
+            workers.emplace_back(Platform::createThread(0, workerEntryFunc, args));
         }
     }
 
-    std::future<I64> PlatformThreadPool::runThread(LocalThreadArgs &&threadArgs) {
-        // Workers pull promises to save futures in them.
-        std::promise<I64> promise;
-        std::future<I64> future = promise.get_future();
-
-        // Sends works to workers
-        {
-            UniqueLock lock(mutexQueue);
-            tasks.emplace(std::make_pair(std::move(promise), std::move(threadArgs)));
+    std::vector<std::future<I64>> PlatformThreadPool::run(std::vector<openmp::LocalThreadArgs> &&threadArgs) {
+        std::vector<std::promise<I64>> newPromises;
+        size_t numThreads = threadArgs.size();
+        newPromises.resize(numThreads);
+        std::vector<std::future<I64>> futures;
+        futures.reserve(numThreads);
+        for (size_t i = 0; i < numThreads; i++) {
+            futures.emplace_back(newPromises[i].get_future());
         }
+        promises = std::move(newPromises);
 
-        condition.notify_one();
-        return future;
+        // Diligently takes the lock, unlikely to be necessary
+        {
+            UniqueLock lock(mutex);
+            runNumber += 1;
+        }
+        workerArgs = std::move(threadArgs);
+        condition.notify_all();
+        return futures;
     }
 
     PlatformThreadPool::~PlatformThreadPool() {
         {
-            UniqueLock lock(mutexQueue);
+            UniqueLock lock(mutex);
             stop = true;
         }
         condition.notify_all();
@@ -79,4 +95,9 @@ namespace wasm {
             Platform::joinThread(worker);
         }
     }
+
+    void PlatformThreadPool::clearPromises() {
+        promises.clear();
+    }
+
 }

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -1289,8 +1289,8 @@ namespace wasm {
         openmp::setTLS(msg.ompthreadnum(), ompLevel);
     }
 
-    std::unique_ptr<PlatformThreadPool> &WAVMWasmModule::getPool() {
-        return ompPool;
+    PlatformThreadPool &WAVMWasmModule::getPool() {
+        return *ompPool;
     }
 
 }

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -1,28 +1,22 @@
-#include "WAVMWasmModule.h"
+#include "wavm/openmp/openmp.h"
 
-#include <wavm/openmp/Level.h>
-#include <wavm/openmp/ThreadState.h>
-
+#include <future>
 #include <WAVM/Platform/Thread.h>
 #include <WAVM/Runtime/Runtime.h>
 #include <WAVM/Runtime/Intrinsics.h>
 
-#include <faasm/array.h>
 #include <state/StateKeyValue.h>
 #include <scheduler/Scheduler.h>
-
 #include <util/timing.h>
+#include <wavm/openmp/Level.h>
+#include <wavm/openmp/ThreadState.h>
+#include <wavm/PlatformThreadPool.h>
+#include <wavm/WAVMWasmModule.h>
+
 
 namespace wasm {
     using namespace openmp;
 
-    struct LocalThreadArgs {
-        int tid = 0;
-        std::shared_ptr<openmp::Level> level = nullptr;
-        wasm::WAVMWasmModule *parentModule;
-        message::Message *parentCall;
-        WasmThreadSpec spec;
-    };
     /**
      * Performs actual static assignment
      */
@@ -216,6 +210,7 @@ namespace wasm {
     static std::string activeSnapshotKey;
     static size_t threadSnapshotSize;
 
+    static std::atomic_int64_t num_threads = 0;
     /**
      * The "real" version of this function is implemented in the openmp source at
      * openmp/runtime/src/kmp_csupport.cpp. This in turn calls __kmp_fork_call which
@@ -250,6 +245,10 @@ namespace wasm {
         // Set up number of threads for next level
         int nextNumThreads = thisLevel->get_next_level_num_threads();
         pushedNumThreads = -1; // Resets for next push
+
+        num_threads.fetch_add(nextNumThreads);
+        logger->error("total num_threads {}, nnt {} at depth {}, ED {}", num_threads, nextNumThreads, thisLevel->depth,
+                      thisLevel->effectiveDepth);
 
         if (0 > userDefaultDevice) {
 
@@ -329,26 +328,19 @@ namespace wasm {
             logger->debug("Distributed Fork finished successfully");
         } else { // Single host
 
-#ifdef OMP_PTS
-            if (nextNumThreads > thisLevel->stackTops.size()) {
-                logger->error("OpenMP needs to allocate more initial stacks than configured max threads");
-                throw std::runtime_error("Too many asked OpenMP threads");
-            }
-#endif
-
             // Set up new level
             auto nextLevel = std::make_shared<SingleHostLevel>(thisLevel, nextNumThreads);
 
             // Note - must ensure thread arguments are outside loop scope otherwise they do
             // may not exist by the time the thread actually consumes them
-            std::vector<LocalThreadArgs> threadArgs;
-            threadArgs.reserve(nextNumThreads);
+//            std::vector<LocalThreadArgs> threadArgs;
+//            threadArgs.reserve(nextNumThreads);
 
             std::vector<std::vector<IR::UntaggedValue>> microtaskArgs;
             microtaskArgs.reserve(nextNumThreads);
 
-            std::vector<WAVM::Platform::Thread *> platformThreads;
-            platformThreads.reserve(nextNumThreads);
+            std::vector<std::future<I64>> threadsFutures;
+            threadsFutures.reserve(nextNumThreads);
 
             // Build up arguments
             for (int threadNum = 0; threadNum < nextNumThreads; threadNum++) {
@@ -365,37 +357,25 @@ namespace wasm {
 
                 // Arguments for spawning the thread
                 // NOTE - CLion auto-format insists on this layout... and clangd really hates C99 extensions
-                threadArgs.push_back({
-                                             .tid = threadNum,
-                                             .level = nextLevel,
-                                             .parentModule = parentModule,
-                                             .parentCall = parentCall,
-                                             .spec = {
-                                                     .contextRuntimeData = contextRuntimeData,
-                                                     .func = func,
-                                                     .funcArgs = microtaskArgs[threadNum].data(),
-#ifdef OMP_PTS
-                                                     .stackTop = thisLevel->stackTops.size() > 0 ? thisLevel->stackTops[threadNum] : parentModule->allocateThreadStack(),
-#else
-                                                     .stackTop = parentModule->allocateThreadStack(),
-#endif
-                                             }
-                                     });
-            }
+                LocalThreadArgs threadArgs = {
+                        .tid = threadNum,
+                        .level = nextLevel,
+                        .parentModule = parentModule,
+                        .parentCall = parentCall,
+                        .spec = {
+                                .contextRuntimeData = contextRuntimeData,
+                                .func = func,
+                                .funcArgs = microtaskArgs[threadNum].data(),
+                        }
+                };
 
-            // Create the threads themselves
-            for (int threadNum = 0; threadNum < nextNumThreads; threadNum++) {
-                platformThreads.emplace_back(Platform::createThread(
-                        0,
-                        ompThreadEntryFunc,
-                        &threadArgs[threadNum]
-                ));
+                threadsFutures.emplace_back(parentModule->getPool()->runThread(std::move(threadArgs)));
             }
 
             // Await all threads
             I64 numErrors = 0;
-            for (auto t: platformThreads) {
-                numErrors += Platform::joinThread(t);
+            for (auto &f : threadsFutures) {
+                numErrors += f.get();
             }
 
             if (numErrors) {


### PR DESCRIPTION
Trying to minimize the contention on the queue I came up with this design. It is 2x slower than the queue design, in its current shape, and also with the following modifications:
1. take lvalue instead of rvalue in `run` and save a pointer to the `LocalThreadArgs` in the class
1. Instead of a global mutex, make a mutex per thread on thread creation so the thread can self regulate (and count on memory ordering to safely modify shared variables `stop` and `runNumber`) 

It seems that this design is flawed, I'm opening this just in case I want to roll back quickly to it